### PR TITLE
Player Death - Chain Stays on Fall

### DIFF
--- a/player/player.gd
+++ b/player/player.gd
@@ -133,9 +133,10 @@ func kill(which_body: RigidBody2D, type: KillType) -> void:
 	# ball_a.hide()
 	# ball_b.hide()
 	
-	for node in $PlayerChain.get_children():
-		if node is PinJoint2D:
-			node.queue_free()
+	if type != KillType.Fall:
+		for node in $PlayerChain.get_children():
+			if node is PinJoint2D:
+				node.queue_free()
 
 	killed.emit(which_body, type)
 	$RespawnTimer.start()


### PR DESCRIPTION
Previously the chain would explode on fall - now it doesn't, when you fall (tho it does still for other death types).